### PR TITLE
updated to pytorch 1.1.0 & nvidia-dali to 1.2.0

### DIFF
--- a/dataloaders.py
+++ b/dataloaders.py
@@ -12,6 +12,7 @@ from nvidia.dali.plugin import pytorch
 import nvidia.dali.ops as ops
 import nvidia.dali.types as types
 
+
 class VideoReaderPipeline(Pipeline):
 	''' Pipeline for reading H264 videos based on NVIDIA DALI.
 	Returns a batch of sequences of `sequence_length` frames of shape [N, F, C, H, W]
@@ -34,27 +35,27 @@ class VideoReaderPipeline(Pipeline):
 		step: (int, optional, default=-1)
 				Frame interval between each sequence (if `step` < 0, `step` is set to `sequence_length`).
 	'''
-	def __init__(self, batch_size, sequence_length, num_threads, device_id, files, \
+	def __init__(self, batch_size, sequence_length, num_threads, device_id, files,
 				 crop_size, random_shuffle=True, step=-1):
 		super(VideoReaderPipeline, self).__init__(batch_size, num_threads, device_id, seed=12)
-		#Define VideoReader
-		self.reader = ops.VideoReader(device="gpu", \
-										filenames=files, \
-										sequence_length=sequence_length, \
-										normalized=False, \
-										random_shuffle=random_shuffle, \
-										image_type=types.RGB, \
-										dtype=types.UINT8, \
-										step=step, \
+		# Define VideoReader
+		self.reader = ops.VideoReader(device="gpu",
+										filenames=files,
+										sequence_length=sequence_length,
+										normalized=False,
+										random_shuffle=random_shuffle,
+										image_type=types.DALIImageType.RGB,
+										dtype=types.DALIDataType.UINT8,
+										step=step,
 										initial_fill=16)
 
 		# Define crop and permute operations to apply to every sequence
-		self.crop = ops.CropCastPermute(device="gpu", \
-										crop=crop_size, \
-										output_layout=types.NCHW, \
-										output_dtype=types.FLOAT)
-		self.uniform = ops.Uniform(range=(0.0, 1.0)) # used for random crop
-# 		self.transpose = ops.Transpose(device="gpu", perm=[3, 0, 1, 2])
+		self.crop = ops.CropMirrorNormalize(device="gpu",
+										crop_w=crop_size,
+										crop_h=crop_size,
+										output_layout='FCHW',
+										dtype=types.DALIDataType.FLOAT)
+		self.uniform = ops.Uniform(range=(0.0, 1.0))  # used for random crop
 
 	def define_graph(self):
 		'''Definition of the graph--events that will take place at every sampling of the dataloader.
@@ -63,6 +64,7 @@ class VideoReaderPipeline(Pipeline):
 		input = self.reader(name="Reader")
 		cropped = self.crop(input, crop_pos_x=self.uniform(), crop_pos_y=self.uniform())
 		return cropped
+
 
 class train_dali_loader():
 	'''Sequence dataloader.
@@ -83,19 +85,19 @@ class train_dali_loader():
 			Frame interval between each sequence
 			(if `temp_stride` < 0, `temp_stride` is set to `sequence_length`).
 	'''
-	def __init__(self, batch_size, file_root, sequence_length, \
+	def __init__(self, batch_size, file_root, sequence_length,
 				 crop_size, epoch_size=-1, random_shuffle=True, temp_stride=-1):
 		# Builds list of sequence filenames
 		container_files = os.listdir(file_root)
 		container_files = [file_root + '/' + f for f in container_files]
 		# Define and build pipeline
-		self.pipeline = VideoReaderPipeline(batch_size=batch_size, \
-											sequence_length=sequence_length, \
-											num_threads=2, \
-											device_id=0, \
-											files=container_files, \
-											crop_size=crop_size, \
-											random_shuffle=random_shuffle,\
+		self.pipeline = VideoReaderPipeline(batch_size=batch_size,
+											sequence_length=sequence_length,
+											num_threads=2,
+											device_id=0,
+											files=container_files,
+											crop_size=crop_size,
+											random_shuffle=random_shuffle,
 											step=temp_stride)
 		self.pipeline.build()
 
@@ -104,11 +106,10 @@ class train_dali_loader():
 			self.epoch_size = self.pipeline.epoch_size("Reader")
 		else:
 			self.epoch_size = epoch_size
-		self.dali_iterator = pytorch.DALIGenericIterator(pipelines=self.pipeline, \
-														output_map=["data"], \
-														size=self.epoch_size, \
-														auto_reset=True, \
-														stop_at_epoch=False)
+		self.dali_iterator = pytorch.DALIGenericIterator(pipelines=self.pipeline,
+														output_map=["data"],
+														size=self.epoch_size,
+														auto_reset=True)
 
 	def __len__(self):
 		return self.epoch_size

--- a/requirements.yml
+++ b/requirements.yml
@@ -5,16 +5,17 @@ channels:
   - defaults
 dependencies:
   - cuda100=1.0
+  - future=0.18.2
   - opencv=3.4.2
+  - mkl=2020.4
   - pip=20.0.2
   - pycodestyle=2.5.0
   - pytest=5.4.1
   - python=3.6.10
-  - pytorch=1.0.0
+  - pytorch=1.1.0
   - scikit-image=0.16.2
   - torchvision=0.2.1
   - pip:
-    - future==0.18.2
-    - --extra-index-url https://developer.download.nvidia.com/compute/redist/cuda/10.0 nvidia-dali==0.10.0
+    - --extra-index-url https://developer.download.nvidia.com/compute/redist nvidia-dali-cuda100==1.2.0
     - tensorboardx==2.0
 


### PR DESCRIPTION
Rewrote dataloaders.py to support **DALI 1.2.0** because DALI 0.10 is not available to download anymore
DALI 1.2.0 requires at least **pytorch 1.1.0** to work correctly with no errors in this case.
Updated requirements.yml accordingly.