### PR TITLE
change weight tensor to contiguous

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -332,7 +332,7 @@ def svd_orthogonalization(lyr):
 			mat_u, _, mat_v = torch.svd(weights)
 			weights = torch.mm(mat_u, mat_v.t())
 
-			lyr.weight.data = weights.view(f1, f2, c_in, c_out).permute(3, 2, 0, 1).type(dtype)
+			lyr.weight.data = weights.view(f1, f2, c_in, c_out).permute(3, 2, 0, 1).contiguous().type(dtype)
 		except:
 			pass
 	else:


### PR DESCRIPTION
bug fix. In DDP multi-GPU training mode, some thing like this warning will be raised:
`
[W accumulate_grad.h:170] Warning: grad and param do not obey the gradient layout contract. This is not an error, but may impair performance.
grad.sizes() = [64, 768, 1, 1], strides() = [768, 1, 1, 1]
param.sizes() = [64, 768, 1, 1], strides() = [768, 1, 768, 768] (function operator())
`